### PR TITLE
arrumando o bug de pagar - invertia o mes pelo dia

### DIFF
--- a/src/Paginas/AgendaContasPagar.js
+++ b/src/Paginas/AgendaContasPagar.js
@@ -25,8 +25,6 @@ const mesSelecionadoTitulo = [
 const AgendaContasPagar = props => {
   const {navigation, route} = props;
   const [cadastros, setCadastros] = useState([]);
-  const [totalConta, setTotalConta] = useState(0);
-  const [totalPago, setTotalPago] = useState(0);
   const [mesSelecionado, setMesSelecionado] = useState(
     moment()
   );
@@ -87,6 +85,7 @@ const AgendaContasPagar = props => {
           'Cadastro',
           {
             ...item,
+            data: moment(item.data, "DD/MM/YYYY").format("MM/DD/YYYY"),
             valor: +item.valor.replace(',', '.'),
             pago: false,
           },
@@ -98,12 +97,14 @@ const AgendaContasPagar = props => {
 
     const onPressRealizarPagamento = async item => {
       const realm = await getRealm();
+      console.log('item', item)
 
       realm.write(() => {
         realm.create(
           'Cadastro',
           {
             ...item,
+            data: moment(item.data, "DD/MM/YYYY").format("MM/DD/YYYY"),
             valor: +item.valor.replace(',', '.'),
             pago: true,
           },

--- a/src/Paginas/Cadastro.js
+++ b/src/Paginas/Cadastro.js
@@ -30,7 +30,6 @@ const Cadastro = props => {
       .replace('.', '')
       .replace(',', '.');
 
-      console.log('listaConta', listaConta)
     const listaContaAdaptada = listaConta.map((item, index) => {
       return {
         id: idUltimoCadastro + index + 1,


### PR DESCRIPTION
Ao realizar o pagamento, era invertido o dia pelo mês.
Exemplo: titulo com data de vencimento: 01/10/21, ao pagar ficava: 10/01/21, consequentemente o titulo era jogado para o mês de janeiro.